### PR TITLE
fix: update pyyaml and uvloop override to use correct cython package name

### DIFF
--- a/overrides/build-systems.json
+++ b/overrides/build-systems.json
@@ -20748,7 +20748,7 @@
     "setuptools"
   ],
   "pyyaml": [
-    "cython_0",
+    "cython",
     "setuptools"
   ],
   "pyyaml-env-tag": [
@@ -26651,7 +26651,7 @@
     "setuptools"
   ],
   "uvloop": [
-    "cython_0",
+    "cython",
     "setuptools"
   ],
   "uwsgidecorators": [


### PR DESCRIPTION
probably related to python 3.13

[Contribution](https://github.com/nix-community/poetry2nix/blob/master/README.md#contributing) checklist (recommended but not always applicable/required):

- [ ] There's an _[automated test](https://github.com/nix-community/poetry2nix/blob/master/tests/default.nix)_ for this change
- [ ] Commit messages or code include _references to related issues or PRs_ (including third parties)
- [ ] Commit messages are _[conventional](https://www.conventionalcommits.org/)_ - examples from [the log](https://github.com/nix-community/poetry2nix/commits/master) include "feat: add changelog files to fixup hook", "fix(contourpy): allow wheel usage", and "test: add sqlalchemy2 test"
